### PR TITLE
Use pandas to deal with categorical lookups on mixed-type arrays

### DIFF
--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -93,10 +93,6 @@ class TestCategoricalComponent(object):
         d = Data(x=['a', 'b', 'c'])
         assert isinstance(d.get_component('x'), CategoricalComponent)
 
-        with pytest.raises(TypeError) as exc:
-            d = Data(x=np.array(['a', 'b', 'c'], dtype=object))
-        assert exc.value.args[0] == "Numpy object type not supported"
-
     def test_accepts_numpy(self):
         cat_comp = CategoricalComponent(self.array_data)
         assert cat_comp._categorical_data.shape == (4,)
@@ -172,6 +168,14 @@ class TestCategoricalComponent(object):
         second_comp.jitter(method='uniform')
         delta = np.abs(cat_comp._data - second_comp._data).sum()
         assert delta == 0
+
+    def test_object_dtype(self):
+        d = np.array([1, 3, 3, 1, 'a', 'b', 'a'], dtype=object)
+        c = CategoricalComponent(d)
+
+        np.testing.assert_array_equal(c._categories,
+                                      np.array([1, 3, 'a', 'b'], dtype=object))
+        np.testing.assert_array_equal(c._data, [0, 1, 1, 0, 2, 3, 2])
 
     def test_valueerror_on_bad_jitter(self):
 

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -503,3 +503,43 @@ def remove_artists(artists):
             a.remove()
         except ValueError:  # already removed
             pass
+
+
+def unique(array):
+    """
+    Return the unique elements of the array U, as well as
+    the index array I such that U[I] == array
+
+    :param array: The array to use
+    :returns: U, I
+    :rtype: tuple of arrays
+    """
+    # numpy.unique doesn't handle mixed-types on python3,
+    # so we use pandas
+    U, I = pd.factorize(array, sort=True)
+    return I, U
+
+
+def row_lookup(data, categories):
+    """
+    Lookup which row in categories each data item is equal to
+
+    :param data: array-like
+    :param categories: array-like of unique values
+
+    :returns: Float array.
+              If result[i] is finite, then data[i] = categoreis[result[i]]
+              Otherwise, data[i] is not in the categories list
+    """
+
+    # np.searchsorted doesn't work on mixed types in Python3
+
+    ndata, ncat = len(data), len(categories)
+    data = pd.DataFrame({'data': data, 'row': np.arange(ndata)})
+    cats = pd.DataFrame({'categories': categories,
+                         'cat_row': np.arange(ncat)})
+
+    m = pd.merge(data, cats, left_on='data', right_on='categories')
+    result = np.zeros(ndata, dtype=float) * np.nan
+    result[m.row] = m.cat_row
+    return result


### PR DESCRIPTION
This should handle problems associated with using np.searchsorted and np.unique on mixed-type arrays in python3.
