### PR TITLE
Extension to in-place unit conversions on components

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -55,8 +55,9 @@ class Component(object):
                                 'np.datetime64 arrays')
             data = coerce_numeric(data)
             data.setflags(write=False)  # data is read-only
-
-        self._data = data
+            self._data = getattr(data, 'value', data)
+        else:
+            self._data = data
 
     @property
     def units(self):
@@ -180,6 +181,14 @@ class Component(object):
 
         if DASK_INSTALLED and isinstance(data, da.Array):
             return DaskComponent(data, units=units)
+
+        if units is None:
+            try:
+                default_units = str(getattr(data, 'unit', ''))
+                u.Unit(default_units, parse_strict='raise')
+                units = default_units
+            except ValueError:
+                pass
 
         data = np.asarray(data)
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -41,16 +41,18 @@ class Component(object):
     for the data type.
     """
 
-    def __init__(self, data, units=None):
+    def __init__(self, data, units=None, equivalencies=None):
 
-        # The physical units of the data
+        # The physical units of the data and default equivalencies
+        self._equivalencies = equivalencies
         self.units = units
 
         # The actual data
         # subclasses may pass non-arrays here as placeholders.
         if isinstance(data, np.ndarray):
             if data.dtype.kind == 'M':
-                raise TypeError('DateTimeComponent should be used instead of Component for np.datetime64 arrays')
+                raise TypeError('DateTimeComponent should be used instead of Component for '
+                                'np.datetime64 arrays')
             data = coerce_numeric(data)
             data.setflags(write=False)  # data is read-only
 
@@ -62,29 +64,37 @@ class Component(object):
 
     @units.setter
     def units(self, value):
-        if value is None:
+        if value in (None, 'None', 'none'):
             new_units = ''
         else:
             new_units = str(value)
-        if getattr(self, '_original_units', '') == '':
+        if getattr(self, '_original_units', '') in ('', None):
             self._original_units = new_units
-        if not u.Unit(self._original_units).is_equivalent(u.Unit(new_units)):
+        if not u.Unit(self._original_units).is_equivalent(u.Unit(new_units),
+                                                          equivalencies=self._equivalencies):
             raise u.UnitConversionError(f"New unit '{new_units}' must be convertible "
                                         f"from original one '{self._original_units}'")
         self._units = new_units
 
-    def _convert_to_units(self, units):
+    def _convert_to_units(self, units, equivalencies=None):
+        if equivalencies is not None:
+            self._equivalencies = equivalencies
         self.units = units
 
     @property
     def _units_scale(self):
-        return u.Unit(self._original_units).to(u.Unit(self._units))
+        return u.Unit(self._original_units).to(u.Unit(self._units),
+                                               equivalencies=self._equivalencies)
 
     @property
     def data(self):
         """The underlying :class:`~numpy.ndarray`"""
         if self._units != self._original_units:
-            return self._data * self._units_scale
+            if self._equivalencies in (None, []):
+                return self._data * self._units_scale
+            else:
+                return (self._data * u.Unit(self._original_units)).to_value(
+                    u.Unit(self._units), equivalencies=self._equivalencies)
         else:
             return self._data
 
@@ -101,7 +111,7 @@ class Component(object):
     def __getitem__(self, key):
         logging.debug("Using %s to index data of shape %s", key, self.shape)
         if self._units != self._original_units:
-           return self._data[key] * self._units_scale
+            return self._data[key] * self._units_scale
         else:
             return self._data[key]
 
@@ -510,8 +520,9 @@ class DateTimeComponent(Component):
         The data to store, with `~numpy.datetime64` dtype
     """
 
-    def __init__(self, data, units=None):
+    def __init__(self, data, units=None, equivalencies=None):
 
+        self._equivalencies = equivalencies
         self.units = units
 
         if not isinstance(data, np.ndarray) or data.dtype.kind != 'M':
@@ -533,8 +544,10 @@ class DaskComponent(Component):
     A data component powered by a dask array.
     """
 
-    def __init__(self, data, units=None):
+    def __init__(self, data, units=None, equivalencies=None):
+
         self._data = data
+        self._equivalencies = equivalencies
         self.units = units
 
     @property

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1433,9 +1433,9 @@ class Data(BaseCartesianData):
         else:
             raise IncompatibleAttribute(component_id)
 
-    def convert_component_units_to(self, component_id, units):
+    def convert_component_units_to(self, component_id, units, equivalencies=None):
         comp = self.get_component(component_id)
-        comp._convert_to_units(units)
+        comp._convert_to_units(units, equivalencies)
         self._numerical_data_changed()
 
     def to_dataframe(self, index=None):


### PR DESCRIPTION
Extending WIP in #2294 with initial equivalencies support and ability to set units from input `data.unit`, if present.